### PR TITLE
amp placement form links updated

### DIFF
--- a/public_html/amp_alum_plac.html
+++ b/public_html/amp_alum_plac.html
@@ -106,7 +106,7 @@
 		</br>
 		</br>
 		
-        <iframe src="https://docs.google.com/forms/d/e/1FAIpQLSfA6kHL-YXTjCgyoBOMbp47IZ267Md1Ich9D4rdMR3VWXfExA/viewform?embedded=true" width="100%" height="3300px" frameborder="0" marginheight="0" marginwidth="0">Loading…</iframe>
+        <iframe src="https://docs.google.com/forms/d/e/1FAIpQLSdDv7-2OIsiZQPNe6pAtL4RYTRt-O7hVUntdURVX0-MG1jswg/viewform?embedded=true" width="100%" height="3300px" frameborder="0" marginheight="0" marginwidth="0">Loading…</iframe>
 
         <!-- ====== // About Area ====== -->
         <!-- ====== Footer Area ====== -->

--- a/public_html/amp_stud_plac.html
+++ b/public_html/amp_stud_plac.html
@@ -107,7 +107,7 @@
 		</br>
 		
         
-        <iframe src="https://docs.google.com/forms/d/e/1FAIpQLSc3HHwutXMGjzOuTmhB_k72K_fqdfrRUTqPUU9AAi17ESuu3Q/viewform?embedded=true" width="100%" height="90%" frameborder="0" marginheight="0" marginwidth="0">Loading…</iframe>
+        <iframe src="https://docs.google.com/forms/d/e/1FAIpQLSfji_f9R2--aVFo3_11nHqJzCA9RxnaLQxF6rWAGnxreROS5w/viewform?embedded=true" width="100%" height="90%" frameborder="0" marginheight="0" marginwidth="0">Loading…</iframe>
 
         <!-- ====== // About Area ====== -->
         <!-- ====== Footer Area ====== -->

--- a/public_html/initiatives.html
+++ b/public_html/initiatives.html
@@ -4,7 +4,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta charset="UTF-8">
-        <title>SAIL | Intiatives</title>
+        <title>SAIL | Initiatives</title>
         <link href = "assets/images/saillogo.png" rel="icon">
         <!-- ====== Google Fonts ====== -->
         <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600" rel="stylesheet">


### PR DESCRIPTION
## Comments
- [x] Title for the Initiatives page was wrong, a typo, Corrected it
- [x] links updated for the amp placement forms 
- [ ] Mentee form has an outdated drive link
- [ ] No bugs, but the poster seemed outdated in the initiatives Page

## Mentee form [http://127.0.0.1:5500/public_html/amp_stud_plac.html](http://127.0.0.1:5500/public_html/amp_stud_plac.html)
![image](https://user-images.githubusercontent.com/79211216/171987224-9af26b51-ea0d-4c15-83cf-261aedbf7d47.png)

## Mentors form [http://127.0.0.1:5500/public_html/amp_alum_plac.html](http://127.0.0.1:5500/public_html/amp_alum_plac.html)
![image](https://user-images.githubusercontent.com/79211216/171987236-e7d8a121-f16c-4bed-9cfd-18a2518f7a7f.png)
